### PR TITLE
feat: Add optionnal detailed data per Label

### DIFF
--- a/lib/list-misclassified.js
+++ b/lib/list-misclassified.js
@@ -1,16 +1,26 @@
 const listMisclassifiedPerLabel = require('./list-misclassified-per-label');
 
 /**
+* @typedef {Object} PerLabelMisclassified
+* @property {Array.<Prediction>} misclassified
+* @property {Object} perLabel
+* @property {String} perLabel.label
+* @property {Array.<Prediction>} perLabel.misclassified
+*/
+
+/**
 * @param {Array.<Prediction>} opts.groundTruths
 * @param {Array.<ConfidencePrediction>} opts.predictions
 * @param {Number} [iouThreshold = 0.5]
-* @returns {Array.<Prediction>} misclassified predictions
+* @param {Boolean} [perLabel = false]
+* @returns {(Array.<Prediction>|PerLabelMisclassified)} misclassified predictions
 */
 
 module.exports = function ({
 	groundTruths,
 	predictions,
-	iouThreshold
+	iouThreshold,
+	perLabel = false
 }) {
 	if (!Array.isArray(groundTruths)) {
 		throw (new TypeError('groundTruths must be an array'));
@@ -26,8 +36,13 @@ module.exports = function ({
 		const groundTruthsLabel = groundTruths.filter(({label}) => label === l).map(o => Object.assign({}, o, {match: false}));
 		const predictionsLabel = predictions.filter(({label}) => label === l).map(o => Object.assign({}, o, {match: false}));
 
-		return listMisclassifiedPerLabel({groundTruthsLabel, predictionsLabel, iouThreshold});
+		return {label: l, misclassified: listMisclassifiedPerLabel({groundTruthsLabel, predictionsLabel, iouThreshold})};
 	});
 
-	return aps.reduce((a, b) => a.concat(b), []);
+	const misclassified = aps.reduce((a, b) => a.concat(b.misclassified), []);
+
+	if (perLabel) {
+		return {misclassified, perLabel: aps};
+	}
+	return misclassified;
 };

--- a/lib/map.js
+++ b/lib/map.js
@@ -14,6 +14,14 @@ const ap = require('./ap');
 */
 
 /**
+* @typedef {Object} PerLabelMAP
+* @property {Number} mAP
+* @property {Object} aps
+* @property {String} aps.label
+* @property {Number} aps.ap
+*/
+
+/**
 * @typedef {Prediction} ConfidencePrediction
 * @property confidence
 */
@@ -22,12 +30,15 @@ const ap = require('./ap');
 * @param {Array.<Prediction>} opts.groundTruths
 * @param {Array.<ConfidencePrediction>} opts.predictions
 * @param {Number} [iouThreshold = 0.5]
+* @param {Boolean} [perLabel = false]
+* @returns {(Number|PerLabelMAP)} mAP
 */
 
 module.exports = function ({
 	groundTruths,
 	predictions,
-	iouThreshold
+	iouThreshold,
+	perLabel = false
 }) {
 	if (!Array.isArray(groundTruths)) {
 		throw (new TypeError('groundTruths must be an array'));
@@ -43,9 +54,13 @@ module.exports = function ({
 		const groundTruthsLabel = groundTruths.filter(({label}) => label === l).map(o => Object.assign({}, o, {match: false}));
 		const predictionsLabel = predictions.filter(({label}) => label === l).map(o => Object.assign({}, o, {match: false}));
 
-		return ap({groundTruthsLabel, predictionsLabel, iouThreshold});
+		return {label: l, ap: ap({groundTruthsLabel, predictionsLabel, iouThreshold})};
 	});
 
 	const l = aps.length;
-	return aps.reduce((a, b) => a + b, 0) / l;
+	const mAP = aps.reduce((a, b) => a + b.ap, 0) / l;
+	if (perLabel) {
+		return {mAP, aps};
+	}
+	return mAP;
 };

--- a/test/list-misclassified.js
+++ b/test/list-misclassified.js
@@ -69,3 +69,77 @@ test('basic example', t => {
 		bottom: 92
 	}]);
 });
+
+test('test case: if perLabel defined should return object with all misclassified object and an array of misclassified per labels ', t => {
+	const groundTruths = [{
+		filename: 'image1.jpg',
+		label: 'car',
+		left: 22,
+		top: 34,
+		right: 231,
+		bottom: 78
+	}, {
+		filename: 'image1.jpg',
+		label: 'pedestrian',
+		left: 22,
+		top: 34,
+		right: 231,
+		bottom: 78
+	}];
+
+	const predictions = [{
+		filename: 'image1.jpg',
+		confidence: 0.9,
+		label: 'car',
+		left: 25,
+		top: 38,
+		right: 201,
+		bottom: 90
+	}, {
+		filename: 'image1.jpg',
+		label: 'pedestrian',
+		confidence: 0.7,
+		left: 32,
+		top: 39,
+		right: 452,
+		bottom: 92
+	}, {
+		filename: 'image1.jpg',
+		confidence: 0.5,
+		label: 'car',
+		left: 541,
+		top: 42,
+		right: 621,
+		bottom: 94
+	}];
+
+	const res = listMisclassified({
+		groundTruths,
+		predictions,
+		perLabel: true
+	});
+
+	t.true(Array.isArray(res.perLabel));
+	t.true(res.perLabel.length === 2);
+	t.true(res.perLabel[0].label === 'car');
+	t.true(res.perLabel[1].label === 'pedestrian');
+	t.deepEqual(res.misclassified, [{
+		filename: 'image1.jpg',
+		confidence: 0.5,
+		label: 'car',
+		left: 541,
+		top: 42,
+		match: false,
+		right: 621,
+		bottom: 94
+	}, {
+		filename: 'image1.jpg',
+		label: 'pedestrian',
+		confidence: 0.7,
+		left: 32,
+		match: false,
+		top: 39,
+		right: 452,
+		bottom: 92
+	}]);
+});

--- a/test/map.js
+++ b/test/map.js
@@ -198,3 +198,46 @@ test('test case: if iouThreshold defined ', t => {
 	t.true(res >= 0);
 	t.true(res <= 1);
 });
+
+test('test case: if perLabel defined should return details per labels ', t => {
+	const groundTruths = [{
+		filename: 'image1.jpg',
+		label: 'car',
+		left: 22,
+		top: 34,
+		right: 231,
+		bottom: 78
+	}];
+
+	const predictions = [{
+		filename: 'image1.jpg',
+		confidence: 0.9,
+		label: 'car',
+		left: 25,
+		top: 38,
+		right: 201,
+		bottom: 90
+	}, {
+		filename: 'image1.jpg',
+		label: 'pedestrian',
+		confidence: 0.7,
+		left: 32,
+		top: 39,
+		right: 452,
+		bottom: 92
+	}];
+
+	const iouThreshold = 0.6;
+	const res = mAP({
+		groundTruths,
+		predictions,
+		iouThreshold,
+		perLabel: true
+	});
+	t.true(Array.isArray(res.aps));
+	t.true(res.aps.length === 2);
+	t.true(res.aps[0].label === 'car');
+	t.true(res.aps[1].label === 'pedestrian');
+	t.true(res.mAP >= 0);
+	t.true(res.mAP <= 1);
+});


### PR DESCRIPTION
Add an option to get a more detailed response with data per Labels which can be useful to compute metrics per Labels as well as the global ones 